### PR TITLE
DEV: Update plugin-outlet arguments

### DIFF
--- a/javascripts/discourse/templates/components/featured-tiles.hbs
+++ b/javascripts/discourse/templates/components/featured-tiles.hbs
@@ -4,5 +4,5 @@
       {{featured-tile topic=topic}}
     {{/each}}
   </div>
-  {{plugin-outlet name="below-featured-tiles" tagName=""}}
+  {{plugin-outlet name="below-featured-tiles" tagName="" connectorTagName="div"}}
 {{/if}}


### PR DESCRIPTION
Core's defaults are changing in https://github.com/discourse/discourse/pull/13685. This commit ensures the behaviour of this plugin will not change.