### PR TITLE
DEV: update route name, pluginId for modifyClass, lint

### DIFF
--- a/javascripts/discourse/components/featured-tiles.js
+++ b/javascripts/discourse/components/featured-tiles.js
@@ -82,7 +82,7 @@ export default Component.extend({
       ![
         "discovery.latest",
         "discovery.categories",
-        "discovery.latestCategory",
+        "discovery.category",
       ].includes(currentRouteName)
     ) {
       return false;

--- a/javascripts/discourse/initializers/init-featured-tiles.js
+++ b/javascripts/discourse/initializers/init-featured-tiles.js
@@ -6,8 +6,10 @@ export default {
   name: "discourse-featured-tiles",
 
   initialize() {
-    withPluginApi("0.8.9", api => {
+    withPluginApi("0.8.9", (api) => {
       api.modifyClass("controller:preferences/interface", {
+        pluginId: this.name,
+
         @observes("model.id")
         updateShowFeaturedTopicsBanner() {
           // debugger;
@@ -43,9 +45,9 @@ export default {
                 );
               }
             }
-          }
-        }
+          },
+        },
       });
     });
-  }
+  },
 };


### PR DESCRIPTION
Displaying this on category pages works with `discovery.category` and not `discovery.latestCategory`

also added pluginId to modifyClass to fix the console warning 